### PR TITLE
Fix undefined variable notice

### DIFF
--- a/includes/CCTM_OutputFilter.php
+++ b/includes/CCTM_OutputFilter.php
@@ -70,7 +70,7 @@ abstract class CCTM_OutputFilter {
 			return array();
 		}
 		
-		$the_array = array();
+		$output = array();
 		
 		if (is_array($input)) {
 			$this->is_array_input = true;


### PR DESCRIPTION
Fix for PHP notice:
NOTICE: /path/to/wp-content/plugins/custom-content-type-manager/includes/CCTM_OutputFilter.php:90 - Undefined variable: output
